### PR TITLE
remove golang-ci lint

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -11,15 +11,6 @@ permissions:
   contents: write
 
 jobs:
-  analysis:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: Run golangci-lint
-      uses: golangci/golangci-lint-action@v2.5.2
-      with:
-        version: latest
-
   build-and-test:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
It OOMs even locally, times out in CI, I'll remove it temporarily.